### PR TITLE
Improve token expiry and error handling

### DIFF
--- a/lib/powersync.dart
+++ b/lib/powersync.dart
@@ -7,6 +7,6 @@ export 'src/powersync_database.dart';
 export 'src/schema.dart';
 export 'src/connector.dart';
 export 'src/crud.dart';
-export 'src/streaming_sync.dart' show SyncStatus;
+export 'src/sync_status.dart';
 export 'src/uuid.dart';
 export 'src/open_factory.dart';

--- a/lib/src/aborter.dart
+++ b/lib/src/aborter.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+/// Controller to abort asynchronous requests or long-running tasks - either
+/// before or after it started.
+class AbortController {
+  /// True if an abort has been requested.
+  bool aborted = false;
+
+  final Completer<void> _abortRequested = Completer();
+  final Completer<void> _abortCompleter = Completer();
+
+  /// Future that is resolved when an abort has been requested.
+  Future<void> get onAbort {
+    return _abortRequested.future;
+  }
+
+  /// Abort, and wait until aborting is complete.
+  Future<void> abort() async {
+    aborted = true;
+    _abortRequested.complete();
+
+    await _abortCompleter.future;
+  }
+
+  /// Signal that an abort has completed.
+  void completeAbort() {
+    _abortCompleter.complete();
+  }
+
+  /// Signal that an abort has failed.
+  /// Any calls to abort() will fail with this error.
+  void abortError(Object error, [StackTrace? stackTrace]) {
+    _abortCompleter.completeError(error, stackTrace);
+  }
+}

--- a/lib/src/bucket_storage.dart
+++ b/lib/src/bucket_storage.dart
@@ -2,13 +2,14 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
-import 'package:sqlite_async/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/mutex.dart';
+import 'package:sqlite_async/sqlite3.dart' as sqlite;
 
 import 'crud.dart';
 import 'database_utils.dart';
 import 'log.dart';
 import 'schema_logic.dart';
+import 'sync_types.dart';
 import 'uuid.dart';
 
 const compactOperationInterval = 1000;
@@ -799,43 +800,6 @@ class SqliteOp {
   List<dynamic> args;
 
   SqliteOp(this.sql, this.args);
-}
-
-class Checkpoint {
-  final String lastOpId;
-  final String? writeCheckpoint;
-  final List<BucketChecksum> checksums;
-
-  const Checkpoint(
-      {required this.lastOpId, required this.checksums, this.writeCheckpoint});
-
-  Checkpoint.fromJson(Map<String, dynamic> json)
-      : lastOpId = json['last_op_id'],
-        writeCheckpoint = json['write_checkpoint'],
-        checksums = (json['buckets'] as List)
-            .map((b) => BucketChecksum.fromJson(b))
-            .toList();
-}
-
-class BucketChecksum {
-  final String bucket;
-  final int checksum;
-
-  /// Count is informational only
-  final int? count;
-  final String? lastOpId;
-
-  const BucketChecksum(
-      {required this.bucket,
-      required this.checksum,
-      this.count,
-      this.lastOpId});
-
-  BucketChecksum.fromJson(Map<String, dynamic> json)
-      : bucket = json['bucket'],
-        checksum = json['checksum'],
-        count = json['count'],
-        lastOpId = json['last_op_id'];
 }
 
 class SyncLocalDatabaseResult {

--- a/lib/src/powersync_database.dart
+++ b/lib/src/powersync_database.dart
@@ -16,6 +16,7 @@ import 'powersync_update_notification.dart';
 import 'schema.dart';
 import 'schema_logic.dart';
 import 'streaming_sync.dart';
+import 'sync_status.dart';
 
 /// A PowerSync managed database.
 ///
@@ -341,26 +342,6 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
       {Duration? lockTimeout}) async {
     await _initialized;
     return database.writeLock(callback);
-  }
-}
-
-/// Stats of the local upload queue.
-class UploadQueueStats {
-  /// Number of records in the upload queue.
-  int count;
-
-  /// Size of the upload queue in bytes.
-  int? size;
-
-  UploadQueueStats({required this.count, this.size});
-
-  @override
-  String toString() {
-    if (size == null) {
-      return "UploadQueueStats<count: $count>";
-    } else {
-      return "UploadQueueStats<count: $count size: ${size! / 1024}kB>";
-    }
   }
 }
 

--- a/lib/src/powersync_database.dart
+++ b/lib/src/powersync_database.dart
@@ -63,7 +63,6 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
   /// Only has an effect if changed before calling [connect].
   Duration retryDelay = const Duration(seconds: 5);
 
-  SendPort? _streamingSyncPort;
   late Future<void> _initialized;
 
   /// null when disconnected, present when connecting or connected
@@ -133,6 +132,7 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
     return _initialized;
   }
 
+  @override
   bool get closed {
     return database.closed;
   }
@@ -168,7 +168,6 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
           });
         } else if (action == 'init') {
           SendPort port = data[1];
-          _streamingSyncPort = port;
           var throttled = UpdateNotification.throttleStream(
               updates, const Duration(milliseconds: 10));
           updateSubscription = throttled.listen((event) {

--- a/lib/src/stream_utils.dart
+++ b/lib/src/stream_utils.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:http/http.dart';
+import 'dart:convert' as convert;
+
+/// Inject a broadcast stream into another stream.
+Stream<T> addBroadcast<T>(Stream<T> a, Stream<T> broadcast) {
+  var controller = StreamController<T>();
+
+  StreamSubscription<T>? sub1;
+  StreamSubscription<T>? sub2;
+
+  void close() {
+    controller.close();
+    sub1!.cancel();
+    sub2!.cancel();
+  }
+
+  // TODO: backpressure?
+  sub1 = a.listen((event) {
+    controller.add(event);
+  }, onDone: () {
+    close();
+  }, onError: (e) {
+    controller.addError(e);
+    close();
+  });
+
+  sub2 = broadcast.listen((event) {
+    controller.add(event);
+  }, onDone: () {
+    close();
+  }, onError: (e) {
+    controller.addError(e);
+    close();
+  });
+
+  controller.onCancel = () {
+    sub1?.cancel();
+  };
+
+  return controller.stream;
+}
+
+/// Given a raw ByteStream, parse each line as JSON.
+Stream<Object?> ndjson(ByteStream input) {
+  final textInput = input.transform(convert.utf8.decoder);
+  final lineInput = textInput.transform(const convert.LineSplitter());
+  final jsonInput = lineInput.transform(StreamTransformer.fromHandlers(
+      handleData: (String data, EventSink<dynamic> sink) {
+    sink.add(convert.jsonDecode(data));
+  }));
+  return jsonInput;
+}

--- a/lib/src/stream_utils.dart
+++ b/lib/src/stream_utils.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:http/http.dart';
 import 'dart:convert' as convert;
 
+/// Inject a broadcast stream into a normal stream.
 Stream<T> addBroadcast<T>(Stream<T> a, Stream<T> broadcast) {
   return mergeStreams([a, broadcast]);
 }

--- a/lib/src/streaming_sync.dart
+++ b/lib/src/streaming_sync.dart
@@ -29,6 +29,8 @@ class StreamingSyncImplementation {
 
   final StreamController _localPingController = StreamController.broadcast();
 
+  final Duration retryDelay;
+
   DateTime? lastSyncedAt;
 
   StreamingSyncImplementation(
@@ -36,7 +38,8 @@ class StreamingSyncImplementation {
       required this.credentialsCallback,
       this.invalidCredentialsCallback,
       required this.uploadCrud,
-      required this.updateStream}) {
+      required this.updateStream,
+      required this.retryDelay}) {
     _client = http.Client();
     statusStream = _statusStreamController.stream;
   }
@@ -62,7 +65,7 @@ class StreamingSyncImplementation {
             .add(SyncStatus(connected: false, lastSyncedAt: lastSyncedAt));
 
         // On error, wait a little before retrying
-        await Future.delayed(const Duration(milliseconds: 5000));
+        await Future.delayed(retryDelay);
       }
     }
   }
@@ -84,7 +87,7 @@ class StreamingSyncImplementation {
         }
       } catch (e, stacktrace) {
         log.warning('Data upload error', e, stacktrace);
-        await Future.delayed(const Duration(milliseconds: 5000));
+        await Future.delayed(retryDelay);
       }
     }
   }

--- a/lib/src/streaming_sync.dart
+++ b/lib/src/streaming_sync.dart
@@ -60,6 +60,8 @@ class StreamingSyncImplementation {
 
         _statusStreamController
             .add(SyncStatus(connected: false, lastSyncedAt: lastSyncedAt));
+
+        // On error, wait a little before retrying
         await Future.delayed(const Duration(milliseconds: 5000));
       }
     }

--- a/lib/src/sync_status.dart
+++ b/lib/src/sync_status.dart
@@ -1,0 +1,47 @@
+class SyncStatus {
+  /// true if currently connected
+  final bool connected;
+
+  /// Time that a last sync has fully completed, if any
+  /// Currently this is reset to null after a restart
+  final DateTime? lastSyncedAt;
+
+  const SyncStatus({required this.connected, required this.lastSyncedAt});
+
+  @override
+  bool operator ==(Object other) {
+    return (other is SyncStatus &&
+        other.connected == connected &&
+        other.lastSyncedAt == lastSyncedAt);
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(connected, lastSyncedAt);
+  }
+
+  @override
+  String toString() {
+    return "SyncStatus<connected: $connected lastSyncedAt: $lastSyncedAt>";
+  }
+}
+
+/// Stats of the local upload queue.
+class UploadQueueStats {
+  /// Number of records in the upload queue.
+  int count;
+
+  /// Size of the upload queue in bytes.
+  int? size;
+
+  UploadQueueStats({required this.count, this.size});
+
+  @override
+  String toString() {
+    if (size == null) {
+      return "UploadQueueStats<count: $count>";
+    } else {
+      return "UploadQueueStats<count: $count size: ${size! / 1024}kB>";
+    }
+  }
+}

--- a/lib/src/sync_types.dart
+++ b/lib/src/sync_types.dart
@@ -1,0 +1,126 @@
+import 'bucket_storage.dart';
+
+class Checkpoint {
+  final String lastOpId;
+  final String? writeCheckpoint;
+  final List<BucketChecksum> checksums;
+
+  const Checkpoint(
+      {required this.lastOpId, required this.checksums, this.writeCheckpoint});
+
+  Checkpoint.fromJson(Map<String, dynamic> json)
+      : lastOpId = json['last_op_id'],
+        writeCheckpoint = json['write_checkpoint'],
+        checksums = (json['buckets'] as List)
+            .map((b) => BucketChecksum.fromJson(b))
+            .toList();
+}
+
+class BucketChecksum {
+  final String bucket;
+  final int checksum;
+
+  /// Count is informational only
+  final int? count;
+  final String? lastOpId;
+
+  const BucketChecksum(
+      {required this.bucket,
+      required this.checksum,
+      this.count,
+      this.lastOpId});
+
+  BucketChecksum.fromJson(Map<String, dynamic> json)
+      : bucket = json['bucket'],
+        checksum = json['checksum'],
+        count = json['count'],
+        lastOpId = json['last_op_id'];
+}
+
+class StreamingSyncCheckpoint {
+  Checkpoint checkpoint;
+
+  StreamingSyncCheckpoint(this.checkpoint);
+
+  StreamingSyncCheckpoint.fromJson(Map<String, dynamic> json)
+      : checkpoint = Checkpoint.fromJson(json);
+}
+
+class StreamingSyncCheckpointDiff {
+  String lastOpId;
+  List<BucketChecksum> updatedBuckets;
+  List<String> removedBuckets;
+  String? writeCheckpoint;
+
+  StreamingSyncCheckpointDiff(
+      this.lastOpId, this.updatedBuckets, this.removedBuckets);
+
+  StreamingSyncCheckpointDiff.fromJson(Map<String, dynamic> json)
+      : lastOpId = json['last_op_id'],
+        writeCheckpoint = json['write_checkpoint'],
+        updatedBuckets = (json['updated_buckets'] as List)
+            .map((e) => BucketChecksum.fromJson(e))
+            .toList(),
+        removedBuckets = List<String>.from(json['removed_buckets']);
+}
+
+class StreamingSyncCheckpointComplete {
+  String lastOpId;
+
+  StreamingSyncCheckpointComplete(this.lastOpId);
+
+  StreamingSyncCheckpointComplete.fromJson(Map<String, dynamic> json)
+      : lastOpId = json['last_op_id'];
+}
+
+class StreamingSyncKeepalive {
+  int tokenExpiresIn;
+
+  StreamingSyncKeepalive(this.tokenExpiresIn);
+
+  StreamingSyncKeepalive.fromJson(Map<String, dynamic> json)
+      : tokenExpiresIn = json['token_expires_in'];
+}
+
+Object? parseStreamingSyncLine(Map<String, dynamic> line) {
+  if (line.containsKey('checkpoint')) {
+    return Checkpoint.fromJson(line['checkpoint']);
+  } else if (line.containsKey('checkpoint_diff')) {
+    return StreamingSyncCheckpointDiff.fromJson(line['checkpoint_diff']);
+  } else if (line.containsKey('checkpoint_complete')) {
+    return StreamingSyncCheckpointComplete.fromJson(
+        line['checkpoint_complete']);
+  } else if (line.containsKey('data')) {
+    return SyncBucketData.fromJson(line['data']);
+  } else if (line.containsKey('token_expires_in')) {
+    return StreamingSyncKeepalive.fromJson(line);
+  } else {
+    return null;
+  }
+}
+
+class StreamingSyncRequest {
+  List<BucketRequest> buckets;
+  bool includeChecksum = true;
+
+  StreamingSyncRequest(this.buckets);
+
+  Map<String, dynamic> toJson() => {
+        'buckets': buckets,
+        'include_checksum': includeChecksum,
+        // We want the JSON row data as a string
+        'raw_data': true
+      };
+}
+
+class BucketRequest {
+  String name;
+  String after;
+
+  BucketRequest(this.name, this.after);
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'after': after,
+      };
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ dev_dependencies:
   test_api: ^0.4.18
   path_provider: ^2.0.13
   sqlite3: ^1.10.1
+  shelf: ^1.4.1
+  shelf_router: ^1.1.4
 
 platforms:
   android:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dev_dependencies:
   sqlite3: ^1.10.1
   shelf: ^1.4.1
   shelf_router: ^1.1.4
+  path: ^1.8.3
 
 platforms:
   android:

--- a/test/bucket_storage_test.dart
+++ b/test/bucket_storage_test.dart
@@ -1,5 +1,6 @@
 import 'package:powersync/powersync.dart';
 import 'package:powersync/src/bucket_storage.dart';
+import 'package:powersync/src/sync_types.dart';
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/mutex.dart';
 import 'package:test/test.dart';

--- a/test/stream_test.dart
+++ b/test/stream_test.dart
@@ -1,0 +1,99 @@
+import 'package:powersync/src/stream_utils.dart';
+import 'package:test/test.dart';
+
+import 'util.dart';
+
+void main() {
+  setupLogger();
+
+  group('Stream Tests', () {
+    setUp(() async {});
+
+    tearDown(() async {});
+
+    Stream<String> genStream(String prefix, Duration delay,
+        [int count = 50, Object? error]) async* {
+      for (var i = 0; i < count; i++) {
+        yield "$prefix $i";
+        await Future.delayed(delay);
+      }
+      if (error != null) {
+        throw error;
+      }
+    }
+
+    test('addBroadcast - basic', () async {
+      Stream<String> stream1 = genStream('S1:', Duration(milliseconds: 5));
+      Stream<String> stream2 =
+          genStream('S2:', Duration(milliseconds: 20)).asBroadcastStream();
+
+      var merged = addBroadcast(stream1, stream2);
+
+      var data = await merged.take(20).toList();
+      var countS1 =
+          data.where((element) => element.startsWith('S1')).toList().length;
+      var countS2 =
+          data.where((element) => element.startsWith('S2')).toList().length;
+      expect(countS1 + countS2, equals(20));
+      expect(countS1, greaterThanOrEqualTo(10));
+      expect(countS2, greaterThanOrEqualTo(0));
+    });
+
+    test('addBroadcast - errors', () async {
+      Object simulatedError = AssertionError('Closed');
+      Stream<String> stream1 =
+          genStream('S1:', Duration(milliseconds: 5), 5, simulatedError);
+      Stream<String> stream2 =
+          genStream('S2:', Duration(milliseconds: 20)).asBroadcastStream();
+
+      var merged = addBroadcast(stream1, stream2);
+
+      List<String> result = [];
+      Object? error;
+      try {
+        await for (var data in merged) {
+          result.add(data);
+        }
+      } catch (e) {
+        error = e;
+      }
+      expect(error, equals(simulatedError));
+      expect(result.length, greaterThanOrEqualTo(5));
+    });
+
+    test('addBroadcast - re-use broadcast after error', () async {
+      Object simulatedError = AssertionError('Closed');
+      Stream<String> stream1 =
+          genStream('S1:', Duration(milliseconds: 5), 5, simulatedError);
+      Stream<String> sb =
+          genStream('SB:', Duration(milliseconds: 20)).asBroadcastStream();
+
+      var merged = addBroadcast(stream1, sb);
+
+      List<String> result = [];
+      Object? error;
+      try {
+        await for (var data in merged) {
+          result.add(data);
+        }
+      } catch (e) {
+        error = e;
+      }
+      expect(error, equals(simulatedError));
+      expect(result.length, greaterThanOrEqualTo(5));
+
+      Stream<String> stream3 = genStream('S3:', Duration(milliseconds: 5));
+
+      var merged2 = addBroadcast(stream3, sb);
+
+      var data = await merged2.take(20).toList();
+      var countS1 =
+          data.where((element) => element.startsWith('S3')).toList().length;
+      var countS2 =
+          data.where((element) => element.startsWith('SB')).toList().length;
+      expect(countS1 + countS2, equals(20));
+      expect(countS1, greaterThanOrEqualTo(10));
+      expect(countS2, greaterThanOrEqualTo(0));
+    });
+  });
+}

--- a/test/stream_test.dart
+++ b/test/stream_test.dart
@@ -66,6 +66,37 @@ void main() {
       expect(result.length, greaterThanOrEqualTo(5));
     });
 
+    test('addBroadcast - errors on cancel', () async {
+      Object simulatedError = AssertionError('Closed');
+      Stream<String> stream2 =
+          genStream('S2:', Duration(milliseconds: 20)).asBroadcastStream();
+
+      var controller = StreamController();
+      var stream1 = controller.stream;
+
+      var merged = addBroadcast(stream1, stream2);
+
+      controller.add('S1: 0');
+      controller.add('S1: 1');
+      controller.add('S1: 2');
+      controller.onCancel = () async {
+        throw simulatedError;
+      };
+
+      List<String> result = [];
+      Object? error;
+      try {
+        await for (var data in merged) {
+          result.add(data);
+          break;
+        }
+      } catch (e) {
+        error = e;
+      }
+      expect(error, equals(simulatedError));
+      expect(result.length, equals(1));
+    });
+
     test('addBroadcast - re-use broadcast after error', () async {
       Object simulatedError = AssertionError('Closed');
       Stream<String> stream1 =

--- a/test/streaming_sync_test.dart
+++ b/test/streaming_sync_test.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:powersync/powersync.dart';
+import 'package:test/test.dart';
+
+import 'test_server.dart';
+import 'util.dart';
+
+class TestConnector extends PowerSyncBackendConnector {
+  final Function _fetchCredentials;
+
+  TestConnector(this._fetchCredentials);
+
+  @override
+  Future<PowerSyncCredentials?> fetchCredentials() {
+    return _fetchCredentials();
+  }
+
+  @override
+  Future<void> uploadData(PowerSyncDatabase database) async {}
+}
+
+void main() {
+  setupLogger();
+
+  group('Streaming Sync Test', () {
+    late String path;
+
+    setUp(() async {
+      path = dbPath();
+      await cleanDb(path: path);
+    });
+
+    tearDown(() async {
+      await cleanDb(path: path);
+    });
+
+    test('full powersync reconnect', () async {
+      // Test repeatedly creating new PowerSync connections, then disconnect
+      // and close the connection.
+      final random = Random();
+
+      for (var i = 0; i < 10; i++) {
+        var server = await createServer();
+
+        credentialsCallback() async {
+          final endpoint = 'http://${server.address.host}:${server.port}';
+          return PowerSyncCredentials(
+              endpoint: endpoint,
+              token: 'token',
+              userId: 'u1',
+              expiresAt: DateTime.now());
+        }
+
+        final pdb = await setupPowerSync(path: path);
+        pdb.retryDelay = Duration(milliseconds: 5000);
+        var connector = TestConnector(credentialsCallback);
+        pdb.connect(connector: connector);
+
+        await Future.delayed(Duration(milliseconds: random.nextInt(100)));
+        if (random.nextBool()) {
+          server.close(force: true).ignore();
+        }
+
+        await pdb.close();
+
+        server.close(force: true).ignore();
+      }
+    });
+
+    test('powersync connection errors', () async {
+      // Test repeatedly killing the streaming connection
+      // Errors like this are expected:
+      //
+      //   [PowerSync] WARNING: 2023-06-29 16:05:24.810002: Sync error
+      //   Connection closed while receiving data
+      //   Write failed
+      //   Connection refused
+      //
+      // Errors like this are not okay:
+      // [PowerSync] WARNING: 2023-06-29 16:10:17.667537: Sync Isolate error
+      // [Connection closed while receiving data, #0      IOClient.send.<anonymous closure> (package:http/src/io_client.dart:76:13)
+
+      HttpServer? server;
+
+      credentialsCallback() async {
+        if (server == null) {
+          throw AssertionError('No active server');
+        }
+        final endpoint = 'http://${server.address.host}:${server.port}';
+        return PowerSyncCredentials(
+            endpoint: endpoint,
+            token: 'token',
+            userId: 'u1',
+            expiresAt: DateTime.now());
+      }
+
+      final pdb = await setupPowerSync(path: path);
+      pdb.retryDelay = const Duration(milliseconds: 5);
+      var connector = TestConnector(credentialsCallback);
+      pdb.connect(connector: connector);
+
+      for (var i = 0; i < 10; i++) {
+        server = await createServer();
+
+        // var stream = impl.streamingSyncRequest(StreamingSyncRequest([]));
+        // 2ms: HttpException: HttpServer is not bound to a socket
+        // 20ms: Connection closed while receiving data
+        await Future.delayed(Duration(milliseconds: 20));
+        server.close(force: true).ignore();
+      }
+      await pdb.close();
+    });
+  });
+}

--- a/test/test_server.dart
+++ b/test/test_server.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+import 'dart:convert' as convert;
+import 'dart:io';
+
+import 'package:http/http.dart' show ByteStream;
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_router/shelf_router.dart';
+
+Future<HttpServer> createServer() async {
+  var app = Router();
+
+  app.post('/sync/stream', handleSyncStream);
+  // Open on an arbitrary open port
+  var server = await shelf_io.serve(app, 'localhost', 0);
+  return server;
+}
+
+/// Convert Map -> ndjson ByteStream
+ByteStream encodeNdjson(Stream<Object> jsonInput) {
+  final stringInput = jsonInput.map((data) => '${convert.jsonEncode(data)}\n');
+  final byteInput = stringInput.transform(convert.utf8.encoder);
+  return ByteStream(byteInput);
+}
+
+Future<Response> handleSyncStream(Request request) async {
+  stream() async* {
+    var blob = "*" * 5000;
+    for (var i = 0; i < 50; i++) {
+      yield {"token_expires_in": 5, "blob": blob};
+      await Future.delayed(Duration(microseconds: 1));
+    }
+  }
+
+  return Response.ok(
+    encodeNdjson(stream()),
+    headers: {
+      'Content-Type': 'application/x-ndjson',
+    },
+    context: {
+      'shelf.io.buffer_output': false,
+    },
+  );
+}

--- a/test/util.dart
+++ b/test/util.dart
@@ -83,7 +83,14 @@ String dbPath() {
 
 setupLogger() {
   Logger.root.level = Level.ALL;
-  Logger.root.onRecord.listen((event) {
-    print(event);
+  Logger.root.onRecord.listen((record) {
+    print(
+        '[${record.loggerName}] ${record.level.name}: ${record.time}: ${record.message}');
+    if (record.error != null) {
+      print(record.error);
+    }
+    if (record.stackTrace != null) {
+      print(record.stackTrace);
+    }
   });
 }

--- a/test/util.dart
+++ b/test/util.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
 
@@ -91,6 +92,16 @@ setupLogger() {
     }
     if (record.stackTrace != null) {
       print(record.stackTrace);
+    }
+
+    if (record.error != null && record.level >= Level.SEVERE) {
+      // Hack to fail the test if a SEVERE error is logged.
+      // Not ideal, but works to catch "Sync Isolate error".
+      uncaughtError() async {
+        throw record.error!;
+      }
+
+      uncaughtError();
     }
   });
 }


### PR DESCRIPTION
Depends on https://github.com/journeyapps/sqlite_async.dart/pull/6.

 * Fix some edge case errors that would kill the sync Isolate.
 * Fix errors when disconnecting shortly after connecting.
 * Improve token expiry - use server notifications to determine whether a token has expired, rather than depending on the local time anymore.
 * `PowerSyncBackendConnector` now automatically caches the token.

Breaking changes:
 * Requires update to sqlite_async.
 * `PowerSyncDatabase.disconnect()` now returns a `Future` instead of `void`.
 * Subclasses of `PowerSyncBackendConnector` must now implement `fetchCredentials()` instead of `refreshCredentials()` + `getCredentials()`.
