### PR TITLE
v0.4.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.1'
+          flutter-version: '3.10.6'
           channel: 'stable'
 
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.1'
+          flutter-version: '3.10.6'
           channel: 'stable'
       - name: Install dependencies
         run: dart pub get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0
+## 0.4.0
 
 Improvements:
  - Some parameters to `PowerSyncCredentials` are now optional.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0
+
+Improvements:
+ - Some parameters to `PowerSyncCredentials` are now optional.
+ - Upgrade dependencies.
+
 ## 0.4.0-preview.6
 
 New functionality:

--- a/lib/src/connector.dart
+++ b/lib/src/connector.dart
@@ -90,8 +90,8 @@ class PowerSyncCredentials {
   const PowerSyncCredentials(
       {required this.endpoint,
       required this.token,
-      required this.userId,
-      required this.expiresAt});
+      this.userId,
+      this.expiresAt});
 
   factory PowerSyncCredentials.fromJson(Map<String, dynamic> parsed) {
     String token = parsed['token'];

--- a/lib/src/open_factory.dart
+++ b/lib/src/open_factory.dart
@@ -30,8 +30,8 @@ class PowerSyncOpenFactory extends DefaultSqliteOpenFactory {
       {required super.path,
       super.sqliteOptions,
       @Deprecated('Override PowerSyncOpenFactory instead')
-          // ignore: deprecated_member_use_from_same_package
-          SqliteConnectionSetup? sqliteSetup})
+      // ignore: deprecated_member_use_from_same_package
+      SqliteConnectionSetup? sqliteSetup})
       // ignore: deprecated_member_use_from_same_package
       : _sqliteSetup = sqliteSetup;
 

--- a/lib/src/powersync_database.dart
+++ b/lib/src/powersync_database.dart
@@ -86,8 +86,8 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
       required String path,
       int maxReaders = SqliteDatabase.defaultMaxReaders,
       @Deprecated("Use [PowerSyncDatabase.withFactory] instead")
-          // ignore: deprecated_member_use_from_same_package
-          SqliteConnectionSetup? sqliteSetup}) {
+      // ignore: deprecated_member_use_from_same_package
+      SqliteConnectionSetup? sqliteSetup}) {
     // ignore: deprecated_member_use_from_same_package
     var factory = PowerSyncOpenFactory(path: path, sqliteSetup: sqliteSetup);
     return PowerSyncDatabase.withFactory(factory, schema: schema);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 0.4.0-preview.7
+version: 0.5.0
 homepage: https://powersync.co
 repository: https://github.com/journeyapps/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,18 @@
 name: powersync
-version: 0.4.0-preview.6
+version: 0.4.0-preview.7
 homepage: https://powersync.co
 repository: https://github.com/journeyapps/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.
 environment:
-  sdk: '>=2.19.1 <3.0.0'
+  sdk: '>=2.19.1 <4.0.0'
 dependencies:
   # Needed because of sqlite3_flutter_libs
   flutter:
     sdk: flutter
 
-  sqlite_async: ^0.4.0
-  sqlite3_flutter_libs: ^0.5.12
-  http: ^0.13.5
+  sqlite_async: ^0.5.0
+  sqlite3_flutter_libs: ^0.5.15
+  http: ^1.1.0
   uuid: ^3.0.7
   async: ^2.10.0
   logging: ^1.1.1
@@ -21,9 +21,9 @@ dependencies:
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.21.0
-  test_api: ^0.4.18
+  test_api: ^0.6.1
   path_provider: ^2.0.13
-  sqlite3: ^1.10.1
+  sqlite3: ^2.1.0
   shelf: ^1.4.1
   shelf_router: ^1.1.4
   path: ^1.8.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 0.5.0
+version: 0.4.0
 homepage: https://powersync.co
 repository: https://github.com/journeyapps/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.


### PR DESCRIPTION
Minor changes only, but can now be considered stable:
 - Some parameters to `PowerSyncCredentials` are now optional.
 - Upgrade dependencies - notably sqlite_async 0.5.x, http 1.x, and explicit dart 3.x support.
